### PR TITLE
fix: READ GITHUBボタン押下時のバグの修正

### DIFF
--- a/app/javascript/components/PortfolioCard.js
+++ b/app/javascript/components/PortfolioCard.js
@@ -39,8 +39,8 @@ export default function PortfolioCard(user) {
       {portfolios.map(portfolio => {
         return(
           <li key={portfolio.id}>
-            <Card className={classes.root} onClick={() => {window.open(portfolio.url, '_blank')}}>
-              <CardActionArea>
+            <Card className={classes.root} >
+              <CardActionArea onClick={() => {window.open(portfolio.url, '_blank')}}>
                 <CardMedia
                   className={classes.media}
                   image={portfolio.image}


### PR DESCRIPTION
## 概要

- READ GITHUBボタン押下時にポートフォリオページとGithubページの両方に遷移されていたバグの修正

画面がない場合は省略可。

## チェックリスト
- [x] rubocopが警告やエラーを出さないこと
- [x] rspecが全てパスしていること

