### PR TITLE
Feat: ポートフォリオ投稿時のエラーハンドリングの作成

### DIFF
--- a/app/controllers/api/v1/portfolios_controller.rb
+++ b/app/controllers/api/v1/portfolios_controller.rb
@@ -8,7 +8,9 @@ class Api::V1::PortfoliosController < ApplicationController
     if portfolio.save
       render json: portfolio
     else
-      render json: portfolio.errors.full_messages, status: :unprocessable_entity
+      errors_keys = portfolio.errors.keys
+      errors = [errors_keys, portfolio.errors.full_messages].transpose.to_h
+      render json: errors, status: :unprocessable_entity
     end
   end
 

--- a/app/javascript/components/atoms/ErrorTextFieldPortfolioDescription.js
+++ b/app/javascript/components/atoms/ErrorTextFieldPortfolioDescription.js
@@ -1,0 +1,18 @@
+import React, { useState } from 'react'
+import TextField from '@material-ui/core/TextField'
+
+export default function ErrorTextFieldPortfolioDescription(props){
+
+  return(
+    <>
+      <TextField
+        error
+        label="ポートフォリオの詳細"
+        variant="outlined"
+        onChange={e => props.inputDescription(e)}
+        helperText={props.errorMessage}
+      />
+    </>
+  )
+}
+

--- a/app/javascript/components/atoms/ErrorTextFieldPortfolioGithub.js
+++ b/app/javascript/components/atoms/ErrorTextFieldPortfolioGithub.js
@@ -1,0 +1,18 @@
+import React, { useState } from 'react'
+import TextField from '@material-ui/core/TextField'
+
+export default function ErrorTextFieldPortfolioGithub(props){
+
+  return(
+    <>
+      <TextField
+        error
+        label="GithubのURL"
+        variant="outlined"
+        onChange={e => props.inputGithub(e)}
+        helperText={props.errorMessage}
+      />
+    </>
+  )
+}
+

--- a/app/javascript/components/atoms/ErrorTextFieldPortfolioImage.js
+++ b/app/javascript/components/atoms/ErrorTextFieldPortfolioImage.js
@@ -1,0 +1,18 @@
+import React, { useState } from 'react'
+import TextField from '@material-ui/core/TextField'
+
+export default function ErrorTextFieldPortfolioImage(props){
+
+  return(
+    <>
+      <TextField
+        error
+        label="ポートフォリオのスクリーンショット"
+        variant="outlined"
+        onChange={e => props.inputImage(e)}
+        helperText={props.errorMessage}
+      />
+    </>
+  )
+}
+

--- a/app/javascript/components/atoms/ErrorTextFieldPortfolioTitle.js
+++ b/app/javascript/components/atoms/ErrorTextFieldPortfolioTitle.js
@@ -1,0 +1,18 @@
+import React, { useState } from 'react'
+import TextField from '@material-ui/core/TextField'
+
+export default function ErrorTextFieldPortfolioTitle(props){
+
+  return(
+    <>
+      <TextField
+        error
+        label="ポートフォリオのタイトル"
+        variant="outlined"
+        onChange={e => props.inputTitle(e)}
+        helperText={props.errorMessage}
+      />
+    </>
+  )
+}
+

--- a/app/javascript/components/atoms/ErrorTextFieldPortfolioUrl.js
+++ b/app/javascript/components/atoms/ErrorTextFieldPortfolioUrl.js
@@ -1,0 +1,18 @@
+import React, { useState } from 'react'
+import TextField from '@material-ui/core/TextField'
+
+export default function ErrorTextFieldPortfolioUrl(props){
+
+  return(
+    <>
+      <TextField
+        error
+        label="ポートフォリオのURL"
+        variant="outlined"
+        onChange={e => props.inputUrl(e)}
+        helperText={props.errorMessage}
+      />
+    </>
+  )
+}
+

--- a/app/javascript/components/atoms/TextFieldPortfolioDescription.js
+++ b/app/javascript/components/atoms/TextFieldPortfolioDescription.js
@@ -1,0 +1,17 @@
+import React, { useState } from 'react'
+import TextField from '@material-ui/core/TextField'
+
+export default function TextFieldPortfolioDescription({description, inputDescription}){
+
+  return(
+    <>
+      <TextField
+        label="ポートフォリオの説明"
+        variant="outlined"
+        value={description}
+        onChange={e => inputDescription(e)}
+      />
+    </>
+  )
+}
+

--- a/app/javascript/components/atoms/TextFieldPortfolioGithub.js
+++ b/app/javascript/components/atoms/TextFieldPortfolioGithub.js
@@ -1,0 +1,17 @@
+import React, { useState } from 'react'
+import TextField from '@material-ui/core/TextField'
+
+export default function TextFieldPortfolioGithub({github, inputGithub}){
+
+  return(
+    <>
+      <TextField
+        label="GithubのURL"
+        variant="outlined"
+        value={github}
+        onChange={e => inputGithub(e)}
+      />
+    </>
+  )
+}
+

--- a/app/javascript/components/atoms/TextFieldPortfolioImage.js
+++ b/app/javascript/components/atoms/TextFieldPortfolioImage.js
@@ -1,0 +1,17 @@
+import React, { useState } from 'react'
+import TextField from '@material-ui/core/TextField'
+
+export default function TextFieldPortfolioGithub({image, inputImage}){
+
+  return(
+    <>
+      <TextField
+        label="ポートフォリオのスクリーンショット"
+        variant="outlined"
+        value={image}
+        onChange={e => inputImage(e)}
+      />
+    </>
+  )
+}
+

--- a/app/javascript/components/atoms/TextFieldPortfolioTitle.js
+++ b/app/javascript/components/atoms/TextFieldPortfolioTitle.js
@@ -1,0 +1,17 @@
+import React, { useState } from 'react'
+import TextField from '@material-ui/core/TextField'
+
+export default function TextFieldPortfolioTitle({title, inputTitle}){
+
+  return(
+    <>
+      <TextField
+        label="ポートフォリオのタイトル"
+        variant="outlined"
+        value={title}
+        onChange={e => inputTitle(e)}
+      />
+    </>
+  )
+}
+

--- a/app/javascript/components/atoms/TextFieldPortfolioUrl.js
+++ b/app/javascript/components/atoms/TextFieldPortfolioUrl.js
@@ -1,0 +1,17 @@
+import React, { useState } from 'react'
+import TextField from '@material-ui/core/TextField'
+
+export default function TextFieldPortfolioUrl({url, inputUrl}){
+
+  return(
+    <>
+      <TextField
+        label="ポートフォリオのURL"
+        variant="outlined"
+        value={url}
+        onChange={e => inputUrl(e)}
+      />
+    </>
+  )
+}
+

--- a/app/javascript/components/pages/CreatePortfolioPage.js
+++ b/app/javascript/components/pages/CreatePortfolioPage.js
@@ -1,10 +1,22 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import Container from '@material-ui/core/Container'
 import Button from '@material-ui/core/Button'
 import TextField from '@material-ui/core/TextField'
 import { useHistory } from "react-router-dom"
 import axios from 'axios'
+
+import TextFieldPortfolioTitle from '../atoms/TextFieldPortfolioTitle'
+import TextFieldPortfolioDescription from '../atoms/TextFieldPortfolioDescription'
+import TextFieldPortfolioGithub from '../atoms/TextFieldPortfolioGithub'
+import TextFieldPortfolioUrl from '../atoms/TextFieldPortfolioUrl'
+import TextFieldPortfolioImage from '../atoms/TextFieldPortfolioImage'
+
+import ErrorTextFieldPortfolioTitle from '../atoms/ErrorTextFieldPortfolioTitle'
+import ErrorTextFieldPortfolioDescription from '../atoms/ErrorTextFieldPortfolioDescription'
+import ErrorTextFieldPortfolioGithub from '../atoms/ErrorTextFieldPortfolioGithub'
+import ErrorTextFieldPortfolioUrl from '../atoms/ErrorTextFieldPortfolioUrl'
+import ErrorTextFieldPortfolioImage from '../atoms/ErrorTextFieldPortfolioImage'
 
 const csrf_token = document.getElementsByName("csrf-token")[0].getAttribute("content")
 axios.defaults.headers.common["X-CSRF-Token"] = csrf_token
@@ -17,7 +29,28 @@ export default function CreatePortfolioForm() {
   const [url, setUrl] = useState('')
   const [image, setImage] = useState('')
   const [userId, setUserId] = useState(1)
+  const [errorMessages, setErrorMessages] = useState({})
   const history = useHistory()
+
+  function inputTitle(e){
+    setTitle(e.target.value)
+  }
+
+  function inputDescription(e){
+    setDescription(e.target.value)
+  }
+
+  function inputGithub(e){
+    setGithub(e.target.value)
+  }
+
+  function inputUrl(e){
+    setUrl(e.target.value)
+  }
+
+  function inputImage(e){
+    setImage(e.target.value)
+  }
 
   async function createPortfolio(e){
     try{
@@ -32,7 +65,7 @@ export default function CreatePortfolioForm() {
       e.preventDefault()
       history.push(`/users/${userId}`)
     }catch(error){
-      console.dir(error)
+      setErrorMessages(error.response.data)
     }
   }
 
@@ -40,39 +73,26 @@ export default function CreatePortfolioForm() {
     <>
       <Container component="main" maxWidth="sm">
         <form className={classes.root}>
-          <TextField
-            label="ポートフォリオのタイトル"
-            variant="outlined"
-            value={title}
-            onChange={e => setTitle(e.target.value)}
-          />
-          <TextField
-            label="ポートフォリオの説明"
-            multiline
-            rows={5}
-            variant="outlined"
-            value={description}
-            onChange={e => setDescription(e.target.value)}
-          />
-          <TextField
-            label="Github URL"
-            variant="outlined"
-            value={github}
-            onChange={e => setGithub(e.target.value)}
-          />
-          <TextField
-            label="ポートフォリオ URL"
-            variant="outlined"
-            value={url}
-            onChange={e => setUrl(e.target.value)}
-          />
-          <TextField
-            label="スクリーンショット"
-            variant="outlined"
-            value={image}
-            onChange={e => setImage(e.target.value)}
-          />
-          {/* 画像投稿は後日実装 */}
+          {errorMessages.title === undefined
+            ? <TextFieldPortfolioTitle title={title} inputTitle={inputTitle} />
+            : <ErrorTextFieldPortfolioTitle title={title} inputTitle={inputTitle} errorMessage={errorMessages.title} />
+          }
+          {errorMessages.description === undefined
+            ? <TextFieldPortfolioDescription description={description} inputDescription={inputDescription} />
+            : <ErrorTextFieldPortfolioDescription description={description} inputDescription={inputDescription} errorMessage={errorMessages.description} />
+          }
+          {errorMessages.github === undefined
+            ? <TextFieldPortfolioGithub github={github} inputGithub={inputGithub} />
+            : <ErrorTextFieldPortfolioGithub github={github} inputGithub={inputGithub} errorMessage={errorMessages.github} />
+          }
+          {errorMessages.url === undefined
+            ? <TextFieldPortfolioUrl url={url} inputUrl={inputUrl} />
+            : <ErrorTextFieldPortfolioUrl url={url} inputUrl={inputUrl} errorMessage={errorMessages.url} />
+          }
+          {errorMessages.image === undefined
+            ? <TextFieldPortfolioImage image={image} inputImage={inputImage} />
+            : <ErrorTextFieldPortfolioImage image={image} inputImage={inputImage} errorMessage={errorMessages.image} />
+          }
         </form>
         <Button
           type="submit"

--- a/spec/requests/api/v1/portfolios/posts_spec.rb
+++ b/spec/requests/api/v1/portfolios/posts_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Api::V1::Portfolios::Post', type: :request do
       end
 
       it 'expect response message ポートフォリオのタイトルを入力してください' do
-        expect(json).to include('ポートフォリオのタイトルを入力してください')
+        expect(json['title']).to include('ポートフォリオのタイトルを入力してください')
       end
     end
 
@@ -68,7 +68,7 @@ RSpec.describe 'Api::V1::Portfolios::Post', type: :request do
       end
 
       it 'expect response message ポートフォリオの説明を入力してください' do
-        expect(json).to include('ポートフォリオの説明を入力してください')
+        expect(json['description']).to include('ポートフォリオの説明を入力してください')
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe 'Api::V1::Portfolios::Post', type: :request do
       end
 
       it 'expect response message GithubのURLを入力してください' do
-        expect(json).to include('GithubのURLを入力してください')
+        expect(json['github']).to include('GithubのURLを入力してください')
       end
     end
 
@@ -98,7 +98,7 @@ RSpec.describe 'Api::V1::Portfolios::Post', type: :request do
       end
 
       it 'expect response message ポートフォリオのURLを入力してください' do
-        expect(json).to include('ポートフォリオのURLを入力してください')
+        expect(json['url']).to include('ポートフォリオのURLを入力してください')
       end
     end
 
@@ -113,7 +113,7 @@ RSpec.describe 'Api::V1::Portfolios::Post', type: :request do
       end
 
       it 'expect response message ポートフォリオのスクリーンショットを入力してください' do
-        expect(json).to include('ポートフォリオのスクリーンショットを入力してください')
+        expect(json['image']).to include('ポートフォリオのスクリーンショットを入力してください')
       end
     end
 


### PR DESCRIPTION
## 概要

- ポートフォリオ投稿時のエラーハンドリングの作成
- 正常時とエラー時のフォームの作成

## 注意事項

現在はフォームが空だった場合のみエラーが表示される。
入力内容が適切で無い場合のエラーは後日実装

## スクリーンショット

![スクリーンショット 2020-11-20 7 55 00](https://user-images.githubusercontent.com/46844364/99734278-de56e680-2b05-11eb-9e00-64e44ba1a614.png)

## チェックリスト
- [x] rubocopが警告やエラーを出さないこと
- [x] rspecが全てパスしていること
- [x] エラー後でも入力が正しく出来る事。

